### PR TITLE
Fixed an issue where releasing the view deck controller would leave an observer hanging

### DIFF
--- a/ViewDeck/IIViewDeckController.m
+++ b/ViewDeck/IIViewDeckController.m
@@ -349,6 +349,7 @@ static inline NSTimeInterval durationToAnimate(CGFloat pointsToAnimate, CGFloat 
     [self cleanup];
     
     self.centerController.viewDeckController = nil;
+    self.centerController = nil;
     self.leftController.viewDeckController = nil;
     self.leftController = nil;
     self.rightController.viewDeckController = nil;


### PR DESCRIPTION
As it currently stands an observer is added for the `title` of the center controller when `- (void)setCenterController:(UIViewController *)centerController` is called. It first removes the old observer if the `_centerController` was not nil and then adds the new observer if the new `_centerController` is not nil.

Currently, the `dealloc` method never sets the center controller to nil and therefore never calls the custom setter which would remove the final observer. So, an observer is left hanging.

I added the setCenterController method and commented on the observer addition and removal to give a better perspective.

``` Objective-c
- (void)setCenterController:(UIViewController *)centerController {
    if ([_centerController isEqual:centerController]) {
        return;
    }

    CGRect currentFrame = self.referenceBounds;

    // start the transition
    if (_centerController) {
        currentFrame = _centerController.view.frame;
        [self prepareCenterForNewController:centerController shouldModifyViewHeirarchy:YES]; // Old observer removed

        [_centerController removeFromParentViewController];
        [_centerController didMoveToParentViewController:nil];
    }

    // make the switch
    _centerController = centerController;

    if (_centerController) {
        // and finish the transition
        [self addChildViewController:_centerController];
        [self configureNewCenterControllerWithFrame:currentFrame modifyViewHeirarchy:YES]; // New observer added

        [_centerController didMoveToParentViewController:self];

        if ([self isAnySideOpen]) {
            [self centerViewHidden];
        }
    }
}
```
